### PR TITLE
Fix keymap and use getActiveTextEditor

### DIFF
--- a/keymaps/guid-me.cson
+++ b/keymaps/guid-me.cson
@@ -8,4 +8,4 @@
 # For more detailed documentation see
 # https://atom.io/docs/latest/behind-atom-keymaps-in-depth
 'atom-text-editor':
-  'ctrl-alt-g': 'guid-me:generate'
+  'ctrl-alt-g': 'guid-me:generate-guid'

--- a/lib/guid-me.coffee
+++ b/lib/guid-me.coffee
@@ -5,6 +5,6 @@ module.exports =
     atom.commands.add 'atom-workspace', "guid-me:generate-guid", => @generateGuid()
 
   generateGuid: ->
-    editor = atom.workspace.getActivePaneItem()
+    editor = atom.workspace.getActiveTextEditor()
     Guid = require 'guid'
     editor.insertText(Guid.raw())


### PR DESCRIPTION
getActivePaneItem has been deprecated and non-functional for a couple of years and the keymap links with the wrong command.